### PR TITLE
Fix `.decendants` with master-part tables where the descendants only contain the part-table

### DIFF
--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -18,7 +18,7 @@ def unite_master_parts(lst):
     """
     for i in range(2, len(lst)):
         name = lst[i]
-        match = re.match(r'(?P<master>`\w+`.`\w+)__\w+`', name)
+        match = re.match(r'(?P<master>`\w+`.`#?\w+)__\w+`', name)
         if match:  # name is a part table
             master = match.group('master')
             for j in range(i-1, -1, -1):

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -26,8 +26,6 @@ def unite_master_parts(lst):
                     # move from the ith position to the (j+1)th position
                     lst[j+1:i+1] = [name] + lst[j+1:i]
                     break
-            else:
-                raise DataJointError("Found a part table {name} without its master table.".format(name=name))
     return lst
 
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -161,6 +161,37 @@ class TestDeclare:
                          {ephys.full_table_name})
 
     @staticmethod
+    def test_descendants_only_contain_part_table():
+        """issue #927"""
+
+        @schema
+        class A(dj.Manual):
+            definition = """
+            a: int
+            """
+
+        @schema
+        class B(dj.Manual):
+            definition = """
+            -> A
+            b: int
+            """
+
+        @schema
+        class Master(dj.Manual):
+            definition = """
+            table_master: int
+            """
+
+            class Part(dj.Part):
+                definition = """
+                -> master
+                -> B
+                """
+
+        assert A.descendants() == ['`djtest_test1`.`a`', '`djtest_test1`.`b`', '`djtest_test1`.`master__part`']
+
+    @staticmethod
     @raises(dj.DataJointError)
     def test_bad_attribute_name():
 


### PR DESCRIPTION
Merging two commits from the official datajoint main branch (not included in official releases yet) that fixe issue datajoint#927

The added function in `test_declare.py` tests the issue when a test framework like `PyTest` is run on the module. It does not impact daily usage.