### PR TITLE
Campatibility with python3.11+

### DIFF
--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -165,7 +165,7 @@ class Blob:
             return self.pack_recarray(np.array(obj))
         if isinstance(obj, np.number):
             return self.pack_array(np.array(obj))
-        if isinstance(obj, (np.bool, np.bool_)):
+        if isinstance(obj, np.bool_):
             return self.pack_array(np.array(obj))
         if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
             return self.pack_datetime(obj)
@@ -366,7 +366,7 @@ class Blob:
         raw_data = [
             tuple(self.read_blob(n_bytes=int(self.read_value('uint64'))) for _ in range(n_fields))
             for __ in range(n_elem)]
-        data = np.array(raw_data, dtype=list(zip(field_names, repeat(np.object))))
+        data = np.array(raw_data, dtype=list(zip(field_names, repeat(object))))
         return self.squeeze(data.reshape(shape, order="F"), convert_to_scalar=False).view(MatStruct)
 
     def pack_struct(self, array):

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -1,5 +1,5 @@
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from collections import Mapping
+from collections.abc import Mapping
 from tqdm import tqdm
 from .settings import config
 from .errors import DataJointError, MissingExternalFile

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -59,7 +59,7 @@ log_levels = {
 }
 
 
-class Config(collections.MutableMapping):
+class Config(collections.abc.MutableMapping):
 
     instance = None
 

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -292,7 +292,7 @@ class Table(QueryExpression):
                 attr = heading[name]
                 if attr.adapter:
                     value = attr.adapter.put(value)
-                if value is None or (attr.numeric and (value == '' or np.isnan(np.float(value)))):
+                if value is None or (attr.numeric and (value == '' or np.isnan(float(value)))):
                     # set default value
                     placeholder, value = 'DEFAULT', None
                 else:  # not NULL
@@ -623,7 +623,7 @@ class Table(QueryExpression):
             value = blob.pack(value)
             placeholder = '%s'
         elif attr.numeric:
-            if value is None or np.isnan(np.float(value)):  # nans are turned into NULLs
+            if value is None or np.isnan(float(value)):  # nans are turned into NULLs
                 placeholder = 'NULL'
                 value = None
             else:


### PR DESCRIPTION
A few modifications for allowing compatibility with python 3.11+. Changes are 
1. collection function calls and imports
2. numpy datatype syntax 

These changes (and the python_3.11+ branch) are **NOT** backwards compatible. 